### PR TITLE
Rename methods

### DIFF
--- a/Example/Example/SceneDelegate.swift
+++ b/Example/Example/SceneDelegate.swift
@@ -38,7 +38,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: scene)
 
         // Defining the user to test
-        let user = magicBell.forUser(email: "richard@example.com")
+        let user = magicBell.connectUser(email: "richard@example.com")
 
         switch style {
         case .uiKit:

--- a/Example/Example/SwiftUI/MagicBellView.swift
+++ b/Example/Example/SwiftUI/MagicBellView.swift
@@ -162,7 +162,7 @@ struct MagicBellView: View {
 }
 
 struct MagicBellView_Previews: PreviewProvider {
-    static let user = magicBell.forUser(email: "john@doe.com")
+    static let user = magicBell.connectUser(email: "richard@example.com")
     static var previews: some View {
         NavigationView {
             MagicBellView(store: user.store.forAll())

--- a/Example/Example/UIKit/MagicBellStoreViewController.swift
+++ b/Example/Example/UIKit/MagicBellStoreViewController.swift
@@ -102,7 +102,7 @@ class MagicBellStoreViewController: UIViewController,
                 guard let email = alert.textFields?.first?.text else {
                     return
                 }
-                self.user = magicBell.forUser(email: email)
+                self.user = magicBell.connectUser(email: email)
                 self.configureStore(predicate: StorePredicate())
             })
             self.present(alert, animated: true, completion: nil)

--- a/README.md
+++ b/README.md
@@ -178,17 +178,17 @@ When the user is logged out from your application you want to:
 - Stop the real-time connection with the MagicBell API
 - Unregister the device from push notifications
 
-This can be achieved with the `removeUserFor` method of the `MagicBell` client instance:
+This can be achieved with the `disconnectUser` method of the `MagicBell` client instance:
 
 ```swift
 // Remove by email
-magicbell.removeUserFor(email: "richard@example.com")
+magicbell.disconnectUser(email: "richard@example.com")
 
 // Remove by external id
-magicbell.removeUserFor(externalId: "001")
+magicbell.disconnectUser(externalId: "001")
 
 // Remove by email and external id
-magicbell.removeUserFor(email: "richard@example.com", externalId: "001")
+magicbell.disconnectUser(email: "richard@example.com", externalId: "001")
 ```
 
 ### Integrating into your app
@@ -578,7 +578,7 @@ func application(_ application: UIApplication, didRegisterForRemoteNotifications
 MagicBell will keep that device token stored temporarly in memory and send it as soon as new users are declared via
 `MagicBellClient.connectUser`.
 
-Whe a user is disconnected (`MagicBellClient.removeUserFor`), the device token is automatically unregistered for that
+Whe a user is disconnected (`MagicBellClient.disconnectUser`), the device token is automatically unregistered for that
 user.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import MagicBell
 let client = MagicBellClient(apiKey: "[MAGICBELL_API_KEY]")
 
 // Set the MagicBell user
-let user = client.forUser(email: "richard@example.com")
+let user = client.connectUser(email: "richard@example.com")
 
 // Create a store of notifications
 let store = user.store.forAll()
@@ -132,27 +132,27 @@ let magicbell = MagicBellClient(apiKey: "[MAGICBELL_API_KEY]")
 ## User
 
 Requests to the MagicBell API require that you **identify the MagicBell user**. This can be done by calling the
-`forUser(...)` method on the `MagicBellClient` instance with the user's email or external ID:
+`connectUser(...)` method on the `MagicBellClient` instance with the user's email or external ID:
 
 ```swift
 // Identify the user by its email
-let user = magicbell.forUser(email: "richard@example.com")
+let user = magicbell.connectUser(email: "richard@example.com")
 
 // Identify the user by its external id
-let user = magicbell.forUser(externalId: "001")
+let user = magicbell.connectUser(externalId: "001")
 
 // Identify the user by both, email and external id
-let user = magicbell.forUser(email: "richard@example.com", externalId: "001")
+let user = magicbell.connectUser(email: "richard@example.com", externalId: "001")
 ```
 
 You can connect as [many users as you need](#multi-user-support).
 
-**IMPORTANT:** `User` instances are singletons. Therefore, calls to the `forUser` method with the same arguments will
+**IMPORTANT:** `User` instances are singletons. Therefore, calls to the `connectUser` method with the same arguments will
 yield the same user:
 
 ```swift
-let userOne = magicbell.forUser(email: "mary@example.com")
-let userTwo = magicbell.forUser(email: "mary@example.com")
+let userOne = magicbell.connectUser(email: "mary@example.com")
+let userTwo = magicbell.connectUser(email: "mary@example.com")
 
 assert(userOne === userTwo, "Both users reference to the same instance")
 ```
@@ -162,12 +162,12 @@ assert(userOne === userTwo, "Both users reference to the same instance")
 If your app suports multiple logins, you may want to display the status of notifications for all logged in users at the
 same time. The MagicBell SDK allows you to that.
 
-You can call the `forUser(:)` method with the email or external ID of your logged in users as many times as you need.
+You can call the `connectUser(:)` method with the email or external ID of your logged in users as many times as you need.
 
 ```swift
-let userOne = magicbell.forUser(email: "richard@example.com")
-let userTwo = magicbell.forUser(email: "mary@example.com")
-let userThree = magicbell.forUser(externalId: "001")
+let userOne = magicbell.connectUser(email: "richard@example.com")
+let userTwo = magicbell.connectUser(email: "mary@example.com")
+let userThree = magicbell.connectUser(externalId: "001")
 ```
 
 ### Logout a User
@@ -216,7 +216,7 @@ struct User {
 extension User {
     /// Returns the logged in MagicBell user
     func magicBell() -> MagicBell.User {
-        return magicbell.forUser(email: email)
+        return magicbell.connectUser(email: email)
     }
 }
 ```
@@ -576,7 +576,7 @@ func application(_ application: UIApplication, didRegisterForRemoteNotifications
 ```
 
 MagicBell will keep that device token stored temporarly in memory and send it as soon as new users are declared via
-`MagicBellClient.forUser`.
+`MagicBellClient.connectUser`.
 
 Whe a user is disconnected (`MagicBellClient.removeUserFor`), the device token is automatically unregistered for that
 user.

--- a/Source/Features/Store/NotificationStore.swift
+++ b/Source/Features/Store/NotificationStore.swift
@@ -19,7 +19,7 @@ import Harmony
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
 public class NotificationStore: Collection, StoreRealTimeObserver {
-    private let pageSize = 20
+    private let pageSize = 50
 
     private let fetchStorePageInteractor: FetchStorePageInteractor
     private let actionNotificationInteractor: ActionNotificationInteractor

--- a/Source/MagicBellClient.swift
+++ b/Source/MagicBellClient.swift
@@ -95,7 +95,7 @@ public class MagicBellClient {
     /// Remove a MagicBell user. All connections are stopped.
     /// - Parameters:
     ///   - email: The user's email
-    public func removeUserFor(email: String) {
+    public func disconnectUser(email: String) {
         let userQuery = UserQuery(email: email)
         removeUser(userQuery: userQuery)
     }
@@ -103,7 +103,7 @@ public class MagicBellClient {
     /// Remove a MagicBell user. All connections are stopped.
     /// - Parameters:
     ///   - externalId: The user's external ID
-    public func removeUserFor(externalId: String) {
+    public func disconnectUser(externalId: String) {
         let userQuery = UserQuery(externalId: externalId)
         removeUser(userQuery: userQuery)
     }
@@ -112,7 +112,7 @@ public class MagicBellClient {
     /// - Parameters:
     ///   - email: The user's email
     ///   - externalId: The user's external ID
-    public func removeUserFor(email: String, externalId: String) {
+    public func disconnectUser(email: String, externalId: String) {
         let userQuery = UserQuery(externalId: externalId, email: email)
         removeUser(userQuery: userQuery)
     }

--- a/Source/MagicBellClient.swift
+++ b/Source/MagicBellClient.swift
@@ -24,12 +24,6 @@ public class MagicBellClient {
     /// The MagicBell SDK version
     public static let version = "1.0.0-alpha.3"
 
-    /// MagicBell's default API URL. Defaults to https://api.magicbell.com.
-    private static let defaultBaseUrl: URL = {
-        // swiftlint:disable force_unwrapping
-        return URL(string: "https://api.magicbell.com")!
-    }()
-
     private let sdkProvider: SDKComponent
 
     private var users: [String: User] = [:]
@@ -47,7 +41,8 @@ public class MagicBellClient {
         apiKey: String,
         apiSecret: String? = nil,
         enableHMAC: Bool = false,
-        baseUrl: URL = MagicBellClient.defaultBaseUrl,
+        // swiftlint:disable force_unwrapping
+        baseUrl: URL = URL(string: "https://api.magicbell.com")!,
         logLevel: LogLevel = .none
     ) {
         sdkProvider = DefaultSDKModule(

--- a/Source/MagicBellClient.swift
+++ b/Source/MagicBellClient.swift
@@ -66,7 +66,7 @@ public class MagicBellClient {
     ///   - email: The user's email
     /// - Returns:
     ///   - An instance of `User`.
-    public func forUser(email: String) -> User {
+    public func connectUser(email: String) -> User {
         let userQuery = UserQuery(email: email)
         return getUser(userQuery)
     }
@@ -76,7 +76,7 @@ public class MagicBellClient {
     ///   - externalId: The user's external ID
     /// - Returns:
     ///   - An instance of `User`.
-    public func forUser(externalId: String) -> User {
+    public func connectUser(externalId: String) -> User {
         let userQuery = UserQuery(externalId: externalId)
         return getUser(userQuery)
     }
@@ -87,7 +87,7 @@ public class MagicBellClient {
     ///   - externalId: The user's external ID
     /// - Returns:
     ///   - An instance of `User`.
-    public func forUser(email: String, externalId: String) -> User {
+    public func connectUser(email: String, externalId: String) -> User {
         let userQuery = UserQuery(externalId: externalId, email: email)
         return getUser(userQuery)
     }

--- a/Tests/Features/Store/NotificationStoreCombineTests.swift
+++ b/Tests/Features/Store/NotificationStoreCombineTests.swift
@@ -14,7 +14,7 @@ import Combine
 
 class NotificationStoreCombineTests: XCTestCase {
 
-    let defaultEdgeArraySize = 20
+    let defaultEdgeArraySize = 50
     lazy var anyIndexForDefaultEdgeArraySize = Int.random(in: 0..<defaultEdgeArraySize)
 
     let userQuery = UserQuery(email: "javier@mobilejazz.com")

--- a/Tests/Features/Store/NotificationStoreRealTimeTests.swift
+++ b/Tests/Features/Store/NotificationStoreRealTimeTests.swift
@@ -18,7 +18,7 @@ import XCTest
 import Nimble
 
 class NotificationStoreRealTimeTests: XCTestCase {
-    let defaultEdgeArraySize = 20
+    let defaultEdgeArraySize = 50
     lazy var anyIndexForDefaultEdgeArraySize = Int.random(in: 0..<defaultEdgeArraySize)
     let userQuery = UserQuery(email: "javier@mobilejazz.com")
 

--- a/Tests/Features/Store/NotificationStoreTests.swift
+++ b/Tests/Features/Store/NotificationStoreTests.swift
@@ -18,7 +18,7 @@ import XCTest
 import Nimble
 
 class NotificationStoreTests: XCTestCase {
-    let defaultEdgeArraySize = 20
+    let defaultEdgeArraySize = 50
     lazy var anyIndexForDefaultEdgeArraySize = Int.random(in: 0..<defaultEdgeArraySize)
 
     let userQuery = UserQuery(email: "javier@mobilejazz.com")


### PR DESCRIPTION
This PR:

- [x] Renames `forUser` to `connectUser`
- [x] Renames `removeForUser` to `disconnectUser`
- [x] Increases the default page size of notification to 50 (the default in MagicBell's API)