### PR TITLE
Rename store methods

### DIFF
--- a/Example/Example/SceneDelegate.swift
+++ b/Example/Example/SceneDelegate.swift
@@ -49,7 +49,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             viewController.user = user
             window?.rootViewController = viewController
         case .swiftUI:
-            let store = user.store.forAll()
+            let store = user.store.build()
             window?.rootViewController = HostingController(rootView: NavigationView {
                 MagicBellView(store: store)
             })

--- a/Example/Example/SwiftUI/MagicBellView.swift
+++ b/Example/Example/SwiftUI/MagicBellView.swift
@@ -162,10 +162,10 @@ struct MagicBellView: View {
 }
 
 struct MagicBellView_Previews: PreviewProvider {
-    static let user = magicBell.forUser(email: "john@doe.com")
+    static let user = magicBell.forUser(email: "richard@example.com")
     static var previews: some View {
         NavigationView {
-            MagicBellView(store: user.store.forAll())
+            MagicBellView(store: user.store.build())
         }
     }
 }

--- a/Example/Example/UIKit/MagicBellStoreViewController.swift
+++ b/Example/Example/UIKit/MagicBellStoreViewController.swift
@@ -139,7 +139,7 @@ class MagicBellStoreViewController: UIViewController,
         store.removeContentObserver(self)
         store.removeCountObserver(self)
 
-        store = user.store.with(predicate: predicate)
+        store = user.store.build(predicate: predicate)
         store.addContentObserver(self)
         store.addCountObserver(self)
 

--- a/Example/Example/UIKit/MagicBellStoreViewController.swift
+++ b/Example/Example/UIKit/MagicBellStoreViewController.swift
@@ -26,7 +26,7 @@ class MagicBellStoreViewController: UIViewController,
     var user: MagicBell.User!
 
     private lazy var store: NotificationStore = {
-        let store = user.store.forAll()
+        let store = user.store.build()
         store.addContentObserver(self)
         store.addCountObserver(self)
         return store

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ let client = MagicBellClient(apiKey: "[MAGICBELL_API_KEY]")
 let user = client.forUser(email: "richard@example.com")
 
 // Create a store of notifications
-let store = user.store.forAll()
+let store = user.store.build()
 
 // Fetch the first page of notifications
 store.fetch { result in
@@ -246,7 +246,6 @@ all notifications using one of these methods of the store instance:
 
 | Method          | Description                        |
 | --------------- | ---------------------------------- |
-| `forAll`        | Fetch all notifications            |
 | `forRead`       | Fetch read notifications only      |
 | `forUnread`     | Fetch unread notifications only    |
 | `forCategories` | Filter notifications by categories |
@@ -255,8 +254,6 @@ all notifications using one of these methods of the store instance:
 For example:
 
 ```swift
-let allNotifications = user.store.forAll()
-
 let readNotifications = user.store.forRead()
 
 let unreadNotifications = user.store.forUnread()
@@ -368,7 +365,7 @@ notifications (read about observers [here](#observing-notification-store-changes
 
 ```swift
 // Obtaining a new notification store (first time)
-let store = user.store.forAll()
+let store = user.store.build()
 
 // First loading
 store.fetch { result in
@@ -466,7 +463,7 @@ protocol NotificationStoreCountObserver: AnyObject {
 To observe changes, implement these protocols (or one of them), and register as an observer to a notification store.
 
 ```swift
-let store = user.store.forAll()
+let store = user.store.build()
 let observer = myObserverClassInstance
 
 store.addContentObserver(observer)

--- a/README.md
+++ b/README.md
@@ -324,12 +324,12 @@ observers of the notification store.
 
 ### Advanced filters
 
-You can also create stores with more advanced filters. To do it, fetch a store using the `.with(...)` method with a
+You can also create stores with more advanced filters. To do it, fetch a store using the `.build(...)` method with a
 `StorePredicate`.
 
 ```swift
 let predicate = StorePredicate()
-let notifications = user.store.with(predicate: predicate)
+let notifications = user.store.build(predicate: predicate)
 ```
 
 These are the available options:
@@ -346,7 +346,7 @@ For example, use this predicate to fetch unread notifications of the `"important
 
 ```swift
 let predicate = StorePredicate(read: .unread, categories: ["important"])
-let store = user.store.with(predicate: predicate)
+let store = user.store.build(predicate: predicate)
 ```
 
 Notification stores are singletons. Creating a store with the same predicate twice will yield the same instance.

--- a/README.md
+++ b/README.md
@@ -241,26 +241,21 @@ You can also inject the MagicBell `User` instance in your own graph and keep tra
 
 ## NotificationStore
 
-The `NotificationStore` class represents a collection of [MagicBell](https://magicbell.com) notifications. You can fetch
-all notifications using one of these methods of the store instance:
-
-| Method          | Description                        |
-| --------------- | ---------------------------------- |
-| `forRead`       | Fetch read notifications only      |
-| `forUnread`     | Fetch unread notifications only    |
-| `forCategories` | Filter notifications by categories |
-| `forTopics`     | Filter notifications by topics     |
+The `NotificationStore` class represents a collection of [MagicBell](https://magicbell.com) notifications. You can
+create an instance of this class through the `.build(...)` method on the user store object.
 
 For example:
 
 ```swift
-let readNotifications = user.store.forRead()
+let allNotifications = user.store.build()
 
-let unreadNotifications = user.store.forUnread()
+let readNotifications = user.store.build(.read)
 
-let billingNotifications = user.store.forCategories(["billing"])
+let unreadNotifications = user.store.build(.unread)
 
-let firstOrderNotifications = user.store.forTopics(["order:001"])
+let billingNotifications = user.store.build(categories: ["billing"])
+
+let firstOrderNotifications = user.store.build(topics: ["order:001"])
 ```
 
 These are the attributes of a notification store:

--- a/Source/Features/Store/StoreDirector.swift
+++ b/Source/Features/Store/StoreDirector.swift
@@ -16,10 +16,16 @@ import Harmony
 
 /// An store director is the class responsible of creating and managing `NotificationStore` objects.
 public protocol StoreDirector {
-    /// Returns a notification store for the given predicate.
+    /// Builds a notification store with the default filters.
     /// - Parameters:
     ///    - predicate: Notification store's predicate. Define an scope for the notification store. Read, Seen, Archive, Categories, Topics and inApp.
-    /// - Returns: A `NotificationStore` with all the actions. MarkNotifications, MarkAllNotifications, FetchNotifications, ReloadStore.
+    /// - Returns: A `NotificationStore`. MarkNotifications, MarkAllNotifications, FetchNotifications, ReloadStore.
+    func build() -> NotificationStore
+
+    /// Builds a notification store for the given predicate.
+    /// - Parameters:
+    ///    - predicate: Notification store's predicate. Define an scope for the notification store. Read, Seen, Archive, Categories, Topics and inApp.
+    /// - Returns: A `NotificationStore`. MarkNotifications, MarkAllNotifications, FetchNotifications, ReloadStore.
     func build(predicate: StorePredicate) -> NotificationStore
 
     /// Disposes a notification store for the given predicate if exists. To be called when a notification store is no longer needed.
@@ -29,12 +35,6 @@ public protocol StoreDirector {
 }
 
 public extension StoreDirector {
-    /// Return the store for all notificaionts
-    /// - Returns: A notification store
-    func forAll() -> NotificationStore {
-        build(predicate: StorePredicate())
-    }
-
     /// Return the store for unread notificaionts
     /// - Returns: A notification store
     func forUnread() -> NotificationStore {
@@ -119,6 +119,10 @@ class RealTimeByPredicateStoreDirector: InternalStoreDirector {
                     startRealTimeConnection()
                 }
             }
+    }
+
+    func build() -> NotificationStore {
+        build(predicate: StorePredicate())
     }
 
     func build(predicate: StorePredicate) -> NotificationStore {

--- a/Source/Features/Store/StoreDirector.swift
+++ b/Source/Features/Store/StoreDirector.swift
@@ -35,30 +35,28 @@ public protocol StoreDirector {
 }
 
 public extension StoreDirector {
-    /// Return the store for unread notificaionts
+    /// Build a store based on the unread state
     /// - Returns: A notification store
-    func forUnread() -> NotificationStore {
-        build(predicate: StorePredicate(read: .unread))
+    func build(_ read: StorePredicate.Read) -> NotificationStore {
+        return build(predicate: StorePredicate(read: read))
     }
 
-    /// Return the store for read notificaionts
+    /// Build a store based on the archived state
     /// - Returns: A notification store
-    func forRead() -> NotificationStore {
-        build(predicate: StorePredicate(read: .read))
+    func build(_ archived: StorePredicate.Archived) -> NotificationStore {
+        return build(predicate: StorePredicate(archived: archived))
     }
 
-    /// Return the store for notifications with the given categories
-    /// - Parameter categories: The list of categories
+    /// Build a store based on the category of notifications
     /// - Returns: A notification store
-    func forCategories(_ categories: [String]) -> NotificationStore {
-        build(predicate: StorePredicate(categories: categories))
+    func build(categories: [String]) -> NotificationStore {
+        return build(predicate: StorePredicate(categories: categories))
     }
 
-    /// Return the store for notifications with the given topics
-    /// - Parameter categories: The list of topics
+    /// Build a store based on the topic of notifications
     /// - Returns: A notification store
-    func forTopics(_ topics: [String]) -> NotificationStore {
-        build(predicate: StorePredicate(topics: topics))
+    func build(topics: [String]) -> NotificationStore {
+        return build(predicate: StorePredicate(topics: topics))
     }
 }
 

--- a/Source/Features/Store/StoreDirector.swift
+++ b/Source/Features/Store/StoreDirector.swift
@@ -25,7 +25,7 @@ public protocol StoreDirector {
     /// Disposes a notification store for the given predicate if exists. To be called when a notification store is no longer needed.
     /// - Parameters:
     ///    - predicate: Notification store's predicate.
-    func disposeWith(predicate: StorePredicate)
+    func dispose(predicate: StorePredicate)
 }
 
 public extension StoreDirector {
@@ -141,7 +141,7 @@ class RealTimeByPredicateStoreDirector: InternalStoreDirector {
         return store
     }
 
-    func disposeWith(predicate: StorePredicate) {
+    func dispose(predicate: StorePredicate) {
         if let storeIndex = stores.firstIndex(where: { $0.predicate.hashValue == predicate.hashValue }) {
             let store = stores[storeIndex]
             storeRealTime.removeObserver(store)

--- a/Source/Features/Store/StoreDirector.swift
+++ b/Source/Features/Store/StoreDirector.swift
@@ -20,7 +20,7 @@ public protocol StoreDirector {
     /// - Parameters:
     ///    - predicate: Notification store's predicate. Define an scope for the notification store. Read, Seen, Archive, Categories, Topics and inApp.
     /// - Returns: A `NotificationStore` with all the actions. MarkNotifications, MarkAllNotifications, FetchNotifications, ReloadStore.
-    func with(predicate: StorePredicate) -> NotificationStore
+    func build(predicate: StorePredicate) -> NotificationStore
 
     /// Disposes a notification store for the given predicate if exists. To be called when a notification store is no longer needed.
     /// - Parameters:
@@ -32,33 +32,33 @@ public extension StoreDirector {
     /// Return the store for all notificaionts
     /// - Returns: A notification store
     func forAll() -> NotificationStore {
-        with(predicate: StorePredicate())
+        build(predicate: StorePredicate())
     }
 
     /// Return the store for unread notificaionts
     /// - Returns: A notification store
     func forUnread() -> NotificationStore {
-        with(predicate: StorePredicate(read: .unread))
+        build(predicate: StorePredicate(read: .unread))
     }
 
     /// Return the store for read notificaionts
     /// - Returns: A notification store
     func forRead() -> NotificationStore {
-        with(predicate: StorePredicate(read: .read))
+        build(predicate: StorePredicate(read: .read))
     }
 
     /// Return the store for notifications with the given categories
     /// - Parameter categories: The list of categories
     /// - Returns: A notification store
     func forCategories(_ categories: [String]) -> NotificationStore {
-        with(predicate: StorePredicate(categories: categories))
+        build(predicate: StorePredicate(categories: categories))
     }
 
     /// Return the store for notifications with the given topics
     /// - Parameter categories: The list of topics
     /// - Returns: A notification store
     func forTopics(_ topics: [String]) -> NotificationStore {
-        with(predicate: StorePredicate(topics: topics))
+        build(predicate: StorePredicate(topics: topics))
     }
 }
 
@@ -121,7 +121,7 @@ class RealTimeByPredicateStoreDirector: InternalStoreDirector {
             }
     }
 
-    func with(predicate: StorePredicate) -> NotificationStore {
+    func build(predicate: StorePredicate) -> NotificationStore {
         if let store = stores.first(where: { $0.predicate.hashValue == predicate.hashValue }) {
             return store
         }

--- a/Tests/Features/Store/NotificationStoreRealTimeTests.swift
+++ b/Tests/Features/Store/NotificationStoreRealTimeTests.swift
@@ -48,7 +48,7 @@ class NotificationStoreRealTimeTests: XCTestCase {
             deleteConfigInteractor: deleteConfigInteractor,
             storeRealTime: storeRealTime)
 
-        return storeDirector.with(predicate: predicate)
+        return storeDirector.build(predicate: predicate)
     }
 
     func test_addRealTimeStore() {


### PR DESCRIPTION
This PR:

- [x] Renames the `.with` method on the StoreDirector to `.build`
- [x] Renames helper methods accordingly